### PR TITLE
Fixed issue with ScheduleRepeating not working if timer Cancelled bef…

### DIFF
--- a/timer.go
+++ b/timer.go
@@ -60,6 +60,7 @@ func NewTimer(ioc *IO) (*Timer, error) {
 // If the delay is negative or 0, the callback is executed as soon as possible.
 func (t *Timer) ScheduleOnce(delay time.Duration, cb func()) (err error) {
 	if t.state == stateReady {
+		t.cancelled = false
 		if delay <= 0 {
 			cb()
 		} else {


### PR DESCRIPTION
Had a problem with the Timer triggering only once when ScheduleRepeating() was called after Cancel() was called from outside the timer's callback (before the timer was scheduled). This PR fixes it