### PR TITLE
Dynamically change a udp multicast peer's read buffer

### DIFF
--- a/multicast/peer.go
+++ b/multicast/peer.go
@@ -554,8 +554,13 @@ func (p *UDPPeer) unblockIPv4(multicastIP, sourceIP netip.Addr) (err error) {
 func (p *UDPPeer) unblockIPv6(multicastIP, sourceIP netip.Addr) (err error) {
 	panic("IPv6 multicast peer not yet supported")
 }
+
 func (p *UDPPeer) Read(b []byte) (int, netip.AddrPort, error) {
 	return p.socket.RecvFrom(b, 0)
+}
+
+func (p *UDPPeer) SetAsyncReadBuffer(to []byte) {
+	p.read.b = to
 }
 
 func (p *UDPPeer) AsyncRead(b []byte, fn func(error, int, netip.AddrPort)) {


### PR DESCRIPTION
Consider the following scenario: (showcased in the test)
- exchange sends data on two multicast groups A and B
- we have 2 udp peers, one for A and one for B which are scheduled to read data
- these 2 udp peers must share the same read buffers. Initially they are both scheduled to read into `b1`.

If peer A reads something in `b1`, peer B must not overwrite what has been read by peer A. Instead, peer B must complete its read into whatever buffer peer A now reads into, say `b2`. That means peer A must change the buffer peer B reads into in its read callback. To summarize: 
- peer A and B schedule an async read into `b1`
- peer A reads and processes what is in `b1` (in its async callback)
- peer B did not read yet. It must not read into `b1`
- peer A schedules itself to read into `b2` and also changes peer B to read into `b2` through `B.SetAsyncReadBuffer` (in peer A's read callback)
- by the end of peer A's read, both peer A and peer B will be scheduled to read into `b2`. 

More concretely, for edxm historical feed `b1`, `b2` etc are chunks obtained from a [bip buffer](https://github.com/talostrading/sonic/blob/master/bip_buffer.go). 