### PR TITLE
Handle empty close frames correctly

### DIFF
--- a/codec/websocket/rfc6455.go
+++ b/codec/websocket/rfc6455.go
@@ -105,9 +105,10 @@ const (
 	// This code is reserved and may not be sent.
 	CloseNone CloseCode = 0
 
-	// CloseNoStatus means no status code was provided even though one was
-	// expected.
-	// This code is reserved and may not be sent.
+	// CloseNoStatus means no status code was provided in the close frame sent
+	// by the peer, even though one was expected.
+	// This code is reserved for internal use and may not be sent in-between
+	// peers.
 	CloseNoStatus CloseCode = 1005
 
 	// CloseAbnormal means the connection was closed without receiving a close

--- a/codec/websocket/util.go
+++ b/codec/websocket/util.go
@@ -52,6 +52,9 @@ func EncodeCloseFramePayload(cc CloseCode, reason string) []byte {
 }
 
 func DecodeCloseFramePayload(b []byte) (cc CloseCode, reason string) {
+	if len(b) < 2 {
+		return CloseNoStatus, ""
+	}
 	cc = DecodeCloseCode(b[:2])
 	reason = string(b[2:])
 	return

--- a/codec/websocket/util_test.go
+++ b/codec/websocket/util_test.go
@@ -1,0 +1,42 @@
+package websocket
+
+import "testing"
+
+func TestCloseFramePayloadCodec(t *testing.T) {
+	{
+		var b []byte = nil
+		code, reason := DecodeCloseFramePayload(b)
+		if !(code == CloseNoStatus && reason == "") {
+			t.Fatal("did not handle empty close frame correctly")
+		}
+	}
+	{
+		b := make([]byte, 1)
+		code, reason := DecodeCloseFramePayload(b)
+		if !(code == CloseNoStatus && reason == "") {
+			t.Fatal("did not handle empty close frame correctly")
+		}
+	}
+	{
+		b := EncodeCloseFramePayload(CloseNormal, "")
+		if len(b) != 2 {
+			t.Fatal("did not encode the close frame correctly")
+		}
+
+		code, reason := DecodeCloseFramePayload(b)
+		if !(code == CloseNormal && reason == "") {
+			t.Fatal("did not handle close frame without reason correctly")
+		}
+	}
+	{
+		b := EncodeCloseFramePayload(CloseNormal, "something")
+		if len(b) != 2+len("something") {
+			t.Fatal("did not encode the close frame correctly")
+		}
+
+		code, reason := DecodeCloseFramePayload(b)
+		if !(code == CloseNormal && reason == "something") {
+			t.Fatal("did not handle close frame with reason correctly")
+		}
+	}
+}


### PR DESCRIPTION
Per the websocket spec, a close frame *MAY* contain some bytes indicating the status and reason for closing the connection. The status will occupy 2 bytes and the reason the rest of the space allowed to a control frame.

Emphasis on *MAY*: this means we must check the close frame has a payload before starting to decode it, otherwise we will trigger a runtime panic by accessing a slice outside it's length.

If no status is given, the websocket spec tells us to return CloseNoStatus=1005, without a reason.

This is something that the validation test suite [autobahn](https://github.com/crossbario/autobahn-python) did not catch and does not test against :(. 