### PR TITLE
remove @0ms because its not a valid update speed per binance docs

### DIFF
--- a/examples/binance/main.go
+++ b/examples/binance/main.go
@@ -13,7 +13,7 @@ var subscriptionMessage = []byte(
 {
   "id": 1,
   "method": "SUBSCRIBE",
-  "params": [ "bnbbtc@depth@0ms" ]
+  "params": [ "bnbbtc@depth" ]
 }
 `)
 


### PR DESCRIPTION
@0ms is not a valid parameter per binance [docs](https://binance-docs.github.io/apidocs/spot/en/#partial-book-depth-streams)