### PR TITLE
Handle abnormal WebSocket close on client (fixes #114)

### DIFF
--- a/codec/websocket/stream.go
+++ b/codec/websocket/stream.go
@@ -234,6 +234,9 @@ func (s *Stream) NextFrame() (f Frame, err error) {
 
 func (s *Stream) nextFrame() (f Frame, err error) {
 	f, err = s.codecConn.ReadNext()
+	if err != nil {
+		s.detectAbnormalClosure(err)
+	}
 	if err == nil {
 		err = s.handleFrame(f)
 	}
@@ -273,11 +276,37 @@ func (s *Stream) asyncNextFrame(callback AsyncFrameCallback) {
 	s.codecConn.AsyncReadNext(func(err error, f Frame) {
 		if err == nil {
 			err = s.handleFrame(f)
-		} else if err == io.EOF {
-			s.state = StateTerminated
+		} else {
+			s.detectAbnormalClosure(err)
 		}
 		callback(err, f)
 	})
+}
+
+// isConnectionError returns true if the error indicates a connection-level issue,
+// such as a non-timeout network error, a connection reset (ECONNRESET), or a broken pipe (EPIPE).
+func isConnectionError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	netErr, ok := err.(net.Error)
+	return ok && !netErr.Timeout() ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.EPIPE)
+}
+
+// detectAbnormalClosure updates the stream state and queues a close frame if the error
+// indicates an abnormal WebSocket closure (e.g., EOF or connection error).
+func (s *Stream) detectAbnormalClosure(err error) {
+	if s.state == StateTerminated {
+		return
+	}
+
+	if err == io.EOF || isConnectionError(err) {
+		s.state = StateTerminated
+		s.prepareClose(EncodeCloseFramePayload(CloseAbnormal, ""))
+	}
 }
 
 // NextMessage reads the payload of the next message into the supplied buffer. Message fragmentation is automatically

--- a/codec/websocket/stream.go
+++ b/codec/websocket/stream.go
@@ -242,11 +242,7 @@ func (s *Stream) nextFrame() (f Frame, err error) {
 
 		// Prepare and return the 1006 close frame directly to client
 		f = NewFrame()
-		fPtr := &f
-		fPtr.
-			SetFIN().
-			SetClose().
-			SetPayload(EncodeCloseFramePayload(CloseAbnormal, ""))
+		f.SetFIN().SetClose().SetPayload(EncodeCloseFramePayload(CloseAbnormal, ""))
 	}
 
 	if err == nil {
@@ -296,11 +292,7 @@ func (s *Stream) asyncNextFrame(callback AsyncFrameCallback) {
 
 			// Prepare and return the 1006 close frame directly
 			f = NewFrame()
-			fPtr := &f
-			fPtr.
-				SetFIN().
-				SetClose().
-				SetPayload(EncodeCloseFramePayload(CloseAbnormal, ""))
+			f.SetFIN().SetClose().SetPayload(EncodeCloseFramePayload(CloseAbnormal, ""))
 		}
 
 		callback(err, f)

--- a/codec/websocket/stream.go
+++ b/codec/websocket/stream.go
@@ -247,9 +247,7 @@ func (s *Stream) nextFrame() (f Frame, err error) {
 			SetFIN().
 			SetClose().
 			SetPayload(EncodeCloseFramePayload(CloseAbnormal, ""))
-
-		return
-}
+	}
 
 	if err == nil {
 		err = s.handleFrame(f)

--- a/codec/websocket/test_main.go
+++ b/codec/websocket/test_main.go
@@ -22,12 +22,21 @@ type MockServer struct {
 	Upgrade *http.Request
 }
 
-func (s *MockServer) Accept(addr string) (err error) {
+// Accept starts the mock server, listening on the specified address.
+// If a callback is provided, it is invoked with the assigned port.
+func (s *MockServer) Accept(addr string, opts ...func(int)) (err error) {
 	s.ln, err = net.Listen("tcp", addr)
 	if err != nil {
 		return err
 	}
-	atomic.StoreInt32(&s.port, int32(s.ln.Addr().(*net.TCPAddr).Port))
+
+	port := int(s.ln.Addr().(*net.TCPAddr).Port)
+	atomic.StoreInt32(&s.port, int32(port))
+
+	// Call port callback if provided
+	if len(opts) > 0 && opts[0] != nil {
+		opts[0](port)
+	}
 
 	conn, err := s.ln.Accept()
 	if err != nil {


### PR DESCRIPTION
Modified the WebSocket Stream to insert the control frame `closed: 1006` when a client tries to read from a stream after it's been abnormally closed by the server. 

In my implementation, 'abnormally closed' means the underlying TCP stream was closed without the WebSocket-level closing handshake (we get an `io.EOF`). I admit I am newer to working with WebSockets on this low of a level, so there may be other cases we need to check.

Previously, tests (and presumably library users) would expect to receive this `io.EOF` error from methods like `nextFrame()` after the connection was abnormally closed, so I maintain this behavior while also returning the aforementioned control frame.

I've also added tests to check correct client behavior on abnormal server close for both synchronous and asynchronous stream methods.

Separately, I recently applied for Talos’s backend internship position. If this is a helpful fix maybe you can look at my application :) It should be under Maxim Maeder / max@mmaeder.com