### PR TITLE
Implement AsyncNextMessageDirect (fixes #150)

### DIFF
--- a/codec/websocket/definitions.go
+++ b/codec/websocket/definitions.go
@@ -100,6 +100,7 @@ func (s StreamState) String() string {
 }
 
 type AsyncMessageCallback = func(err error, n int, messageType MessageType)
+type AsyncMessageDirectCallback = func(err error, messageType MessageType, payloads ...[]byte)
 type AsyncFrameCallback = func(err error, f Frame)
 type ControlCallback = func(messageType MessageType, payload []byte)
 type UpgradeRequestCallback = func(req *http.Request)

--- a/codec/websocket/frame_assembler.go
+++ b/codec/websocket/frame_assembler.go
@@ -1,0 +1,38 @@
+package websocket
+
+// FrameAssembler helps users reassemble a set of payload slices (frames)
+// into a single contiguous buffer.
+type FrameAssembler struct {
+	parts [][]byte
+}
+
+// NewFrameAssembler creates a FrameAssembler with the given parts.
+func NewFrameAssembler(parts ...[]byte) *FrameAssembler {
+	return &FrameAssembler{
+		parts: parts,
+	}
+}
+
+func (fa *FrameAssembler) Append(fragment []byte) {
+	fa.parts = append(fa.parts, fragment)
+}
+
+// Slices returns the underlying slices exactly as stored.
+func (fa *FrameAssembler) Slices() [][]byte {
+	return fa.parts
+}
+
+// Reassemble concatenates all slices into a single new []byte buffer.
+func (fa *FrameAssembler) Reassemble() []byte {
+	total := 0
+	for _, p := range fa.parts {
+		total += len(p)
+	}
+	out := make([]byte, total)
+	offset := 0
+	for _, p := range fa.parts {
+		copy(out[offset:], p)
+		offset += len(p)
+	}
+	return out
+}

--- a/codec/websocket/frame_assembler_test.go
+++ b/codec/websocket/frame_assembler_test.go
@@ -1,0 +1,61 @@
+package websocket
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFrameAssemblerEmpty(t *testing.T) {
+	assembler := NewFrameAssembler()
+	assert.NotNil(t, assembler)
+
+	slices := assembler.Slices()
+	assert.Len(t, slices, 0)
+
+	reassembled := assembler.Reassemble()
+	assert.Equal(t, 0, len(reassembled))
+}
+
+func TestFrameAssemblerSingle(t *testing.T) {
+	payload := []byte{0x01, 0x02, 0x03}
+	assembler := NewFrameAssembler(payload)
+
+	slices := assembler.Slices()
+	assert.Len(t, slices, 1)
+	assert.Equal(t, payload, slices[0])
+
+	reassembled := assembler.Reassemble()
+	assert.Equal(t, payload, reassembled)
+}
+
+func TestFrameAssemblerMulti(t *testing.T) {
+	payload1 := []byte{0x01, 0x02}
+	payload2 := []byte{0x03, 0x04, 0x05}
+	payload3 := []byte{0x06}
+
+	assembler := NewFrameAssembler(payload1, payload2, payload3)
+
+	slices := assembler.Slices()
+	assert.Len(t, slices, 3)
+	assert.Equal(t, payload1, slices[0])
+	assert.Equal(t, payload2, slices[1])
+	assert.Equal(t, payload3, slices[2])
+
+	reassembled := assembler.Reassemble()
+	want := bytes.Join([][]byte{payload1, payload2, payload3}, nil)
+	assert.Equal(t, want, reassembled)
+}
+
+func TestFrameAssemblerAppend(t *testing.T) {
+	assembler := NewFrameAssembler([]byte{0x01}, []byte{0x02})
+	assembler.Append([]byte{0x03, 0x04})
+
+	slices := assembler.Slices()
+	assert.Len(t, slices, 3)
+
+	want := []byte{0x01, 0x02, 0x03, 0x04}
+	reassembled := assembler.Reassemble()
+	assert.Equal(t, want, reassembled)
+}

--- a/codec/websocket/stream.go
+++ b/codec/websocket/stream.go
@@ -1079,3 +1079,134 @@ func (s *Stream) CloseNextLayer() (err error) {
 	}
 	return
 }
+
+// AsyncNextMessageDirect reads the next websocket message asynchronously, returning either
+// one zero-copy slice (if the message fits in one frame) or multiple copied slices
+// (if the message is fragmented).
+//
+// This call first flushes any pending control frames to the underlying stream asynchronously.
+//
+// This call does not block. The provided callback is invoked when one of the following happens:
+//   - an error occurs while flushing the pending control frames
+//   - an error occurs when reading/decoding the message bytes from the underlying stream
+//   - the payload of the message is successfully read
+func (s *Stream) AsyncNextMessageDirect(callback AsyncMessageDirectCallback) {
+	s.AsyncFlush(func(err error) {
+		if errors.Is(err, ErrMessageTooBig) {
+			s.AsyncClose(CloseGoingAway, "payload too big", func(_ error) {})
+			callback(ErrMessageTooBig, TypeNone)
+			return
+		}
+
+		if err == nil && !s.canRead() {
+			err = io.EOF
+		}
+
+		if err == nil {
+			s.asyncNextMessageDirectFirstFrame(callback)
+		} else {
+			s.state = StateTerminated
+			callback(err, TypeNone)
+		}
+	})
+}
+
+// asyncNextMessageDirectFirstFrame reads the first data frame.
+// If it is FIN, we do single-frame zero-copy. Otherwise, we start gathering frames.
+func (s *Stream) asyncNextMessageDirectFirstFrame(cb AsyncMessageDirectCallback) {
+	s.AsyncNextFrame(func(err error, f Frame) {
+		if err != nil {
+			cb(err, TypeNone)
+			return
+		}
+		if f.Opcode().IsControl() {
+			// Handle control frames
+			if s.controlCallback != nil {
+				s.controlCallback(MessageType(f.Opcode()), f.Payload())
+			}
+			s.asyncNextMessageDirectFirstFrame(cb)
+			return
+		}
+
+		mt := MessageType(f.Opcode())
+
+		if f.PayloadLength() > s.maxMessageSize {
+			// Close socket if payload too big
+			s.AsyncClose(CloseGoingAway, "payload too big", func(_ error) {})
+			cb(ErrMessageTooBig, mt)
+			return
+		}
+
+		if f.IsFIN() {
+			// If message is made of a single frame, return that frame's payload (zero copy)
+			cb(nil, mt, f.Payload())
+			return
+		}
+
+		// If message is made of a multiple frames, we must copy each frame's payload
+		// This is because existing codec/ws stream designed around only holding on to one frame at a time
+		payloadCopy := make([]byte, f.PayloadLength())
+		copy(payloadCopy, f.Payload())
+
+		parts := [][]byte{payloadCopy}
+		s.asyncNextMessageDirectFragments(mt, parts, cb)
+	})
+}
+
+// asyncNextMessageDirectFragments reads continuation frames until FIN, storing each payload in parts.
+// For all frames that are not FIN, we do a copy into a new buffer. For the final frame (FIN=true),
+// we append f.Payload() directly (zero-copy).
+func (s *Stream) asyncNextMessageDirectFragments(
+    messageType MessageType,
+    parts [][]byte,
+    cb AsyncMessageDirectCallback,
+) {
+    s.AsyncNextFrame(func(err error, f Frame) {
+        if err != nil {
+            cb(err, messageType, parts...)
+            return
+        }
+        if f.Opcode().IsControl() {
+            // Handle control frames, then keep reading data frames
+            if s.controlCallback != nil {
+                s.controlCallback(MessageType(f.Opcode()), f.Payload())
+            }
+            s.asyncNextMessageDirectFragments(messageType, parts, cb)
+            return
+        }
+        if !f.Opcode().IsContinuation() {
+            // If we encounter a protocol error, close the socket
+            s.AsyncClose(CloseProtocolError, "expected continuation", func(_ error) {})
+            cb(ErrExpectedContinuation, messageType, parts...)
+            return
+        }
+
+        // Check total message size
+        totalSoFar := 0
+        for _, p := range parts {
+            totalSoFar += len(p)
+        }
+        if totalSoFar+f.PayloadLength() > s.maxMessageSize {
+			// Close socket if payload too big
+            s.AsyncClose(CloseGoingAway, "payload too big", func(_ error) {})
+            cb(ErrMessageTooBig, messageType, parts...)
+            return
+        }
+
+        if f.IsFIN() {
+			// If this is final fragment of message, return all of the payload parts
+			// We don't need to copy this final fragment, for the same reason we don't for messages of a
+			// single frame
+            parts = append(parts, f.Payload())
+            cb(nil, messageType, parts...)
+            return
+        }
+
+        // Otherwise, copy this frame and keep reading next fragments
+        payloadCopy := make([]byte, f.PayloadLength())
+        copy(payloadCopy, f.Payload())
+        parts = append(parts, payloadCopy)
+
+        s.asyncNextMessageDirectFragments(messageType, parts, cb)
+    })
+}

--- a/codec/websocket/stream.go
+++ b/codec/websocket/stream.go
@@ -1157,56 +1157,56 @@ func (s *Stream) asyncNextMessageDirectFirstFrame(cb AsyncMessageDirectCallback)
 // For all frames that are not FIN, we do a copy into a new buffer. For the final frame (FIN=true),
 // we append f.Payload() directly (zero-copy).
 func (s *Stream) asyncNextMessageDirectFragments(
-    messageType MessageType,
-    parts [][]byte,
-    cb AsyncMessageDirectCallback,
+	messageType MessageType,
+	parts [][]byte,
+	cb AsyncMessageDirectCallback,
 ) {
-    s.AsyncNextFrame(func(err error, f Frame) {
-        if err != nil {
-            cb(err, messageType, parts...)
-            return
-        }
-        if f.Opcode().IsControl() {
-            // Handle control frames, then keep reading data frames
-            if s.controlCallback != nil {
-                s.controlCallback(MessageType(f.Opcode()), f.Payload())
-            }
-            s.asyncNextMessageDirectFragments(messageType, parts, cb)
-            return
-        }
-        if !f.Opcode().IsContinuation() {
-            // If we encounter a protocol error, close the socket
-            s.AsyncClose(CloseProtocolError, "expected continuation", func(_ error) {})
-            cb(ErrExpectedContinuation, messageType, parts...)
-            return
-        }
+	s.AsyncNextFrame(func(err error, f Frame) {
+		if err != nil {
+			cb(err, messageType, parts...)
+			return
+		}
+		if f.Opcode().IsControl() {
+			// Handle control frames, then keep reading data frames
+			if s.controlCallback != nil {
+				s.controlCallback(MessageType(f.Opcode()), f.Payload())
+			}
+			s.asyncNextMessageDirectFragments(messageType, parts, cb)
+			return
+		}
+		if !f.Opcode().IsContinuation() {
+			// If we encounter a protocol error, close the socket
+			s.AsyncClose(CloseProtocolError, "expected continuation", func(_ error) {})
+			cb(ErrExpectedContinuation, messageType, parts...)
+			return
+		}
 
-        // Check total message size
-        totalSoFar := 0
-        for _, p := range parts {
-            totalSoFar += len(p)
-        }
-        if totalSoFar+f.PayloadLength() > s.maxMessageSize {
+		// Check total message size
+		totalSoFar := 0
+		for _, p := range parts {
+			totalSoFar += len(p)
+		}
+		if totalSoFar+f.PayloadLength() > s.maxMessageSize {
 			// Close socket if payload too big
-            s.AsyncClose(CloseGoingAway, "payload too big", func(_ error) {})
-            cb(ErrMessageTooBig, messageType, parts...)
-            return
-        }
+			s.AsyncClose(CloseGoingAway, "payload too big", func(_ error) {})
+			cb(ErrMessageTooBig, messageType, parts...)
+			return
+		}
 
-        if f.IsFIN() {
+		if f.IsFIN() {
 			// If this is final fragment of message, return all of the payload parts
 			// We don't need to copy this final fragment, for the same reason we don't for messages of a
 			// single frame
-            parts = append(parts, f.Payload())
-            cb(nil, messageType, parts...)
-            return
-        }
+			parts = append(parts, f.Payload())
+			cb(nil, messageType, parts...)
+			return
+		}
 
-        // Otherwise, copy this frame and keep reading next fragments
-        payloadCopy := make([]byte, f.PayloadLength())
-        copy(payloadCopy, f.Payload())
-        parts = append(parts, payloadCopy)
+		// Otherwise, copy this frame and keep reading next fragments
+		payloadCopy := make([]byte, f.PayloadLength())
+		copy(payloadCopy, f.Payload())
+		parts = append(parts, payloadCopy)
 
-        s.asyncNextMessageDirectFragments(messageType, parts, cb)
-    })
+		s.asyncNextMessageDirectFragments(messageType, parts, cb)
+	})
 }

--- a/codec/websocket/stream_test.go
+++ b/codec/websocket/stream_test.go
@@ -1735,3 +1735,116 @@ func TestClientAsyncAbnormalClose(t *testing.T) {
 		ioc.PollOne()
 	}
 }
+
+func TestClientAsyncNextMessageDirectUnfragmented(t *testing.T) {
+	assert := assert.New(t)
+
+	ioc := sonic.MustIO()
+	defer ioc.Close()
+
+	ws, err := NewWebsocketStream(ioc, nil, RoleClient)
+	assert.Nil(err)
+
+	ws.state = StateActive
+	ws.init(nil)
+
+	ws.src.Write([]byte{
+		0x81, 2, 0x01, 0x02, // fin=true, type=text, payload_len=2, payload=[0x01, 0x02]
+	})
+
+	ran := false
+	ws.AsyncNextMessageDirect(func(err error, mt MessageType, payloads ...[]byte) {
+		ran = true
+		assert.Nil(err)            // Verify no error when getting message
+
+		assert.Equal(TypeText, mt) // Verify message type correct
+		assert.Len(payloads, 1)    // Verify we got exactly one payload slice
+
+		assert.Equal([]byte{0x01, 0x02}, payloads[0]) // Verify payload slice correct
+	})
+
+	assert.True(ran)                      // Verify callback ran
+	assert.Equal(StateActive, ws.State()) // Verify ws still in active state
+}
+
+func TestClientAsyncNextMessageDirectFragmented(t *testing.T) {
+	assert := assert.New(t)
+
+	ioc := sonic.MustIO()
+	defer ioc.Close()
+
+	ws, err := NewWebsocketStream(ioc, nil, RoleClient)
+	assert.Nil(err)
+
+	ws.state = StateActive
+	ws.init(nil)
+
+	ws.src.Write([]byte{
+		0x01, 2, 0x01, 0x02,       // fin=false, type=text, payload_len=2, payload=[0x01, 0x02]
+		0x80, 3, 0x03, 0x04, 0x05, // fin=true, type=continuation, payload_len=3, payload=[0x03, 0x04, 0x05]
+	})
+
+	ran := false
+	ws.AsyncNextMessageDirect(func(err error, mt MessageType, payloads ...[]byte) {
+		ran = true
+		assert.Nil(err)            // Verify no error when getting message
+
+		assert.Equal(TypeText, mt) // Verify message type correct
+		assert.Len(payloads, 2)    // Verify we got two payload slices
+
+
+		assert.Equal([]byte{0x01, 0x02}, payloads[0])       // Verify 1st payload slice correct
+		assert.Equal([]byte{0x03, 0x04, 0x05}, payloads[1]) // Verify 2nd payload slice correct
+	})
+
+	assert.True(ran)                      // Verify callback ran
+	assert.Equal(StateActive, ws.State()) // Verify ws still in active state
+}
+
+func TestClientAsyncNextMessageDirectInterleavedControlFrame(t *testing.T) {
+	assert := assert.New(t)
+
+	ioc := sonic.MustIO()
+	defer ioc.Close()
+
+	ws, err := NewWebsocketStream(ioc, nil, RoleClient)
+	assert.Nil(err)
+
+	ws.state = StateActive
+	mock := NewMockStream()
+	ws.init(mock)
+
+	ws.src.Write([]byte{
+		0x01, 2, 0x01, 0x02, // fin=false, type=text, payload_len=2, payload=[0x01, 0x02]
+		0x89, 1, 0xFF,       // fin=true, type=ping (control), payload_len=1, payload=[0xFF]
+		0x80, 2, 0x03, 0x04, // fin=true, type=continuation, payload_len=2, payload=[0x03, 0x04]
+	})
+
+	// To verify our ping gets properly processed
+	controlInvoked := false
+	ws.SetControlCallback(func(mt MessageType, b []byte) {
+		controlInvoked = true
+
+		assert.Equal(TypePing, mt)    // Verify message type correct
+		assert.Equal([]byte{0xFF}, b) // Verify Ping payload correct
+		
+		assert.Equal(1, ws.Pending()) // Verify that a matching Pong queued
+	})
+
+	messageInvoked := false
+	ws.AsyncNextMessageDirect(func(err error, mt MessageType, payloads ...[]byte) {
+		messageInvoked = true
+		assert.Nil(err)            // Verify no error when getting message
+
+		assert.Equal(TypeText, mt) // Verify message type correct
+		assert.Len(payloads, 2)    // Verify we got two payload slices
+
+
+		assert.Equal([]byte{0x01, 0x02}, payloads[0]) // Verify 1st payload slice correct
+		assert.Equal([]byte{0x03, 0x04}, payloads[1]) // Verify 2nd payload slice correct
+	})
+
+	assert.True(controlInvoked)           // Verify control callback ran
+	assert.True(messageInvoked)           // Verify message callback ran
+	assert.Equal(StateActive, ws.State()) // Verify ws still in active state
+}


### PR DESCRIPTION
I've implemented AsyncNextMessageDirect and FrameAssembler as defined in #150, plus tests for both. 

The one issue I ran into is that the websocket stream and codec are both designed to only store one frame in memory at a time. I tried to rewrite this so we could buffer an entire message's worth of frames (so it would be zero-copy), but I kept running into issues as this was a pretty complicated refactor.

The solution I came up with was:
1) If it's a single frame message, just return the reference to the payload (this is zero copy)
2) If the message is multiple frames, copy the intermediate frames to an internal buffer

This obviously is not a perfect solution. I would be happy to continue trying to implement a true zero-copy method, but I would probably need some help or guidance.