### PR TITLE
websocket: read the whole upgrade response, however it arrives (fixes #35)

### DIFF
--- a/codec/websocket/definitions.go
+++ b/codec/websocket/definitions.go
@@ -9,6 +9,7 @@ const (
 	DefaultMaxMessageSize = 1024 * 512
 	CloseTimeout          = 5 * time.Second
 	DialTimeout           = 5 * time.Second
+	HandshakeReadTimeout  = 5 * time.Second
 )
 
 type Role uint8

--- a/codec/websocket/handshake_test.go
+++ b/codec/websocket/handshake_test.go
@@ -1,0 +1,180 @@
+package websocket
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/talostrading/sonic"
+)
+
+func runHandshake(
+	t *testing.T,
+	configure func(*MockServer),
+) (ws *Stream, ioc *sonic.IO, handshakeErr error, cleanup func()) {
+	t.Helper()
+
+	srv := NewMockServer()
+	configure(srv)
+
+	go func() {
+		defer srv.Close()
+		_ = srv.Accept(MockServerDynamicAddr)
+	}()
+
+	ioc = sonic.MustIO()
+
+	ws, err := NewWebsocketStream(ioc, nil, RoleClient)
+	assert.Nil(t, err)
+
+	done := false
+	ws.AsyncHandshake(
+		fmt.Sprintf("ws://127.0.0.1:%d", <-srv.portChan),
+		func(err error) {
+			handshakeErr = err
+			done = true
+		},
+	)
+	for !done {
+		ioc.PollOne()
+	}
+
+	return ws, ioc, handshakeErr, func() {
+		srv.Close()
+		ioc.Close()
+	}
+}
+
+func TestClientHandshakeResponseSplitAcrossReads(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cuts func(res []byte) []int
+	}{
+		{
+			"after the status line",
+			func(res []byte) []int { return []int{10} },
+		},
+		{
+			"inside the headers",
+			func(res []byte) []int { return []int{len(res) / 2} },
+		},
+		{
+			"inside the terminator",
+			func(res []byte) []int {
+				return []int{len(res) - 3, len(res) - 2, len(res) - 1}
+			},
+		},
+		{
+			"every 16 bytes",
+			func(res []byte) (cuts []int) {
+				for i := 16; i < len(res); i += 16 {
+					cuts = append(cuts, i)
+				}
+				return cuts
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err, cleanup := runHandshake(t, func(srv *MockServer) {
+				srv.SendUpgradeResponse = func(conn net.Conn, res []byte) error {
+					prev := 0
+					for _, cut := range append(tc.cuts(res), len(res)) {
+						if _, err := conn.Write(res[prev:cut]); err != nil {
+							return err
+						}
+						time.Sleep(5 * time.Millisecond)
+						prev = cut
+					}
+					return nil
+				}
+			})
+			defer cleanup()
+
+			assert.Nil(t, err)
+		})
+	}
+}
+
+func TestClientHandshakeLargeResponse(t *testing.T) {
+	_, _, err, cleanup := runHandshake(t, func(srv *MockServer) {
+		srv.SendUpgradeResponse = func(conn net.Conn, res []byte) error {
+			cookie := "Set-Cookie: session=" + strings.Repeat("x", 8192) + "\r\n"
+			big := append([]byte{}, res[:len(res)-2]...)
+			big = append(big, cookie...)
+			big = append(big, "\r\n"...)
+			_, err := conn.Write(big)
+			return err
+		}
+	})
+	defer cleanup()
+
+	assert.Nil(t, err)
+}
+
+func TestClientHandshakeFramesBehindNonCanonicalResponse(t *testing.T) {
+	payload := []byte("first frame of the session")
+
+	ws, ioc, err, cleanup := runHandshake(t, func(srv *MockServer) {
+		srv.SendUpgradeResponse = func(conn net.Conn, _ []byte) error {
+			key := MakeResponseKey(
+				[]byte(srv.Upgrade.Header.Get("Sec-WebSocket-Key")),
+			)
+
+			res := bytes.NewBuffer(nil)
+			fmt.Fprintf(res, "HTTP/1.1 101 Switching Protocols\r\n")
+			fmt.Fprintf(res, "upgrade:  websocket\r\n")
+			fmt.Fprintf(res, "connection:  Upgrade\r\n")
+			fmt.Fprintf(res, "sec-websocket-accept:  %s\r\n", key)
+			fmt.Fprintf(res, "\r\n")
+
+			frame := NewFrame()
+			frame.SetFIN()
+			frame.SetText()
+			frame.SetPayload(payload)
+			if _, err := frame.WriteTo(res); err != nil {
+				return err
+			}
+
+			_, err := res.WriteTo(conn)
+			return err
+		}
+	})
+	defer cleanup()
+
+	assert.Nil(t, err)
+
+	b := make([]byte, 128)
+	done := false
+	ws.AsyncNextMessage(b, func(err error, n int, mt MessageType) {
+		assert.Nil(t, err)
+		assert.Equal(t, payload, b[:n])
+		done = true
+	})
+	for !done {
+		ioc.PollOne()
+	}
+}
+
+func TestClientHandshakeStalledResponse(t *testing.T) {
+	start := time.Now()
+
+	_, _, err, cleanup := runHandshake(t, func(srv *MockServer) {
+		srv.SendUpgradeResponse = func(conn net.Conn, res []byte) error {
+			cut := bytes.Index(res, []byte("\r\n")) + 2
+			if _, err := conn.Write(res[:cut]); err != nil {
+				return err
+			}
+			time.Sleep(HandshakeReadTimeout + 2*time.Second)
+			return nil
+		}
+	})
+	defer cleanup()
+
+	assert.ErrorIs(t, err, os.ErrDeadlineExceeded)
+	assert.Less(t, time.Since(start), HandshakeReadTimeout+time.Second)
+}

--- a/codec/websocket/stream.go
+++ b/codec/websocket/stream.go
@@ -15,7 +15,6 @@ when the client cannot parse what the server sends.
 
 import (
 	"bufio"
-	"bytes"
 	"crypto/rand"
 	"crypto/sha1" //#nosec G505
 	"crypto/tls"
@@ -26,10 +25,10 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"sync"
 	"syscall"
+	"time"
 	"unicode/utf8"
 
 	"github.com/talostrading/sonic"
@@ -66,9 +65,6 @@ type Stream struct {
 	// Buffer for stream writes.
 	dst *sonic.ByteBuffer
 
-	// Contains the handshake response. Is emptied after the handshake is over.
-	handshakeBuffer []byte
-
 	// Contains frames waiting to be sent to the peer. Is emptied by AsyncFlush or Flush.
 	pendingFrames []*Frame
 
@@ -100,8 +96,7 @@ func NewWebsocketStream(ioc *sonic.IO, tls *tls.Config, role Role) (s *Stream, e
 		dst:   sonic.NewByteBuffer(),
 		state: StateHandshake,
 		/* #nosec G401 */
-		hasher:          sha1.New(),
-		handshakeBuffer: make([]byte, 1024),
+		hasher: sha1.New(),
 		dialer: &net.Dialer{
 			Timeout: DialTimeout,
 		},
@@ -158,7 +153,6 @@ func (s *Stream) init(stream sonic.Stream) (err error) {
 }
 
 func (s *Stream) reset() {
-	s.handshakeBuffer = s.handshakeBuffer[:cap(s.handshakeBuffer)]
 	s.state = StateHandshake
 	s.stream = nil
 	s.conn = nil
@@ -943,32 +937,25 @@ func (s *Stream) upgrade(uri *url.URL, stream sonic.Stream, headers []Header) er
 		return err
 	}
 
-	s.handshakeBuffer = s.handshakeBuffer[:cap(s.handshakeBuffer)]
-	n, err := stream.Read(s.handshakeBuffer)
-	if err != nil {
-		return err
+	if s.conn != nil {
+		if err := s.conn.SetReadDeadline(
+			time.Now().Add(HandshakeReadTimeout),
+		); err != nil {
+			return err
+		}
+		defer func() { _ = s.conn.SetReadDeadline(time.Time{}) }()
 	}
-	s.handshakeBuffer = s.handshakeBuffer[:n]
-	rd := bytes.NewReader(s.handshakeBuffer)
-	res, err := http.ReadResponse(bufio.NewReader(rd), req)
+
+	br := bufio.NewReaderSize(stream, 4096)
+	res, err := http.ReadResponse(br, req)
 	if err != nil {
 		return err
 	}
 
-	rawRes, err := httputil.DumpResponse(res, true)
-	if err != nil {
-		return err
+	if n := br.Buffered(); n > 0 {
+		extra, _ := br.Peek(n)
+		_, _ = s.src.Write(extra)
 	}
-
-	resLen := len(rawRes)
-	extra := len(s.handshakeBuffer) - resLen
-	if extra > 0 {
-		// we got some frames as well with the handshake so we can put
-		// them in src for later decoding before clearing the handshake
-		// buffer
-		_, _ = s.src.Write(s.handshakeBuffer[resLen:])
-	}
-	s.handshakeBuffer = s.handshakeBuffer[:0]
 
 	if s.upgradeResponseCallback != nil {
 		s.upgradeResponseCallback(res)

--- a/codec/websocket/test_main.go
+++ b/codec/websocket/test_main.go
@@ -21,6 +21,8 @@ type MockServer struct {
 	portChan chan int
 
 	Upgrade *http.Request
+
+	SendUpgradeResponse func(conn net.Conn, res []byte) error
 }
 
 func NewMockServer() *MockServer {
@@ -84,6 +86,10 @@ func (s *MockServer) Accept(addr string) (err error) {
 		MakeResponseKey([]byte(s.Upgrade.Header.Get("Sec-WebSocket-Key"))),
 	)
 	fmt.Fprintf(res, "\r\n")
+
+	if s.SendUpgradeResponse != nil {
+		return s.SendUpgradeResponse(s.conn, res.Bytes())
+	}
 
 	_, err = res.WriteTo(s.conn)
 	return err


### PR DESCRIPTION
The client read the upgrade response with a single Read into a fixed
1KB buffer, failing handshakes whose response spans multiple reads or
outgrows the buffer. Parse it with http.ReadResponse over a bufio.Reader
on the stream instead, under a read deadline (HandshakeReadTimeout).

Trailing frames are whatever bufio has left over, so they are taken
byte-exact off the wire instead of via httputil.DumpResponse, whose
re-serialized length can disagree with the wire and corrupt the first
frames of the session.

Suite passes on macOS (darwin/arm64) and Linux amd64 (golang:1.24 container).