### PR TITLE
websocket: deflake the test suite

### DIFF
--- a/codec/websocket/client_performance_test.go
+++ b/codec/websocket/client_performance_test.go
@@ -29,7 +29,7 @@ func TestClientReadWrite(t *testing.T) {
 
 	go func() {
 		defer s.Close()
-		if err := s.Accept("localhost:0"); err != nil {
+		if err := s.Accept("127.0.0.1:0"); err != nil {
 			panic(err)
 		}
 
@@ -97,7 +97,7 @@ func TestClientReadWrite(t *testing.T) {
 	}
 
 	client.AsyncHandshake(
-		fmt.Sprintf("ws://localhost:%d", s.Port()),
+		fmt.Sprintf("ws://127.0.0.1:%d", s.Port()),
 		onHandshake,
 	)
 

--- a/codec/websocket/stream_test.go
+++ b/codec/websocket/stream_test.go
@@ -69,7 +69,7 @@ func TestClientServerSendsInvalidCloseCode(t *testing.T) {
 	}
 
 	done := false
-	ws.AsyncHandshake(fmt.Sprintf("ws://localhost:%d", <-srv.portChan), func(err error) {
+	ws.AsyncHandshake(fmt.Sprintf("ws://127.0.0.1:%d", <-srv.portChan), func(err error) {
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -132,7 +132,7 @@ func TestClientEchoCloseCode(t *testing.T) {
 	}
 
 	done := false
-	ws.AsyncHandshake(fmt.Sprintf("ws://localhost:%d", <-srv.portChan), func(err error) {
+	ws.AsyncHandshake(fmt.Sprintf("ws://127.0.0.1:%d", <-srv.portChan), func(err error) {
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -201,7 +201,7 @@ func TestClientSendPingWithInvalidPayload(t *testing.T) {
 	}
 
 	done := false
-	ws.AsyncHandshake(fmt.Sprintf("ws://localhost:%d", <-srv.portChan), func(err error) {
+	ws.AsyncHandshake(fmt.Sprintf("ws://127.0.0.1:%d", <-srv.portChan), func(err error) {
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -252,7 +252,7 @@ func TestClientSendMessageWithPayload126(t *testing.T) {
 	}
 
 	done := false
-	ws.AsyncHandshake(fmt.Sprintf("ws://localhost:%d", <-srv.portChan), func(err error) {
+	ws.AsyncHandshake(fmt.Sprintf("ws://127.0.0.1:%d", <-srv.portChan), func(err error) {
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -306,7 +306,7 @@ func TestClientSendMessageWithPayload127(t *testing.T) {
 	}
 
 	done := false
-	ws.AsyncHandshake(fmt.Sprintf("ws://localhost:%d", <-srv.portChan), func(err error) {
+	ws.AsyncHandshake(fmt.Sprintf("ws://127.0.0.1:%d", <-srv.portChan), func(err error) {
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -335,7 +335,7 @@ func TestClientReconnectOnFailedRead(t *testing.T) {
 		for i := 0; i < 10; i++ {
 			var err error
 			if port != 0 {
-				err = srv.Accept(fmt.Sprintf("localhost:%d", port))
+				err = srv.Accept(fmt.Sprintf("127.0.0.1:%d", port))
 			} else {
 				err = srv.Accept(MockServerDynamicAddr)
 			}
@@ -397,7 +397,7 @@ func TestClientReconnectOnFailedRead(t *testing.T) {
 	}
 
 	connect = func() {
-		ws.AsyncHandshake(fmt.Sprintf("ws://localhost:%d", port), onHandshake)
+		ws.AsyncHandshake(fmt.Sprintf("ws://127.0.0.1:%d", port), onHandshake)
 	}
 
 	connect()
@@ -453,7 +453,7 @@ func TestClientFailedHandshakeNoServer(t *testing.T) {
 	}
 
 	done := false
-	ws.AsyncHandshake("ws://localhost:8081", func(err error) {
+	ws.AsyncHandshake("ws://127.0.0.1:8081", func(err error) {
 		done = true
 		if err == nil {
 			t.Fatal("expected error")
@@ -508,7 +508,7 @@ func TestClientSuccessfulHandshake(t *testing.T) {
 
 	assertState(t, ws, StateHandshake)
 
-	ws.AsyncHandshake(fmt.Sprintf("ws://localhost:%d", <-srv.portChan), func(err error) {
+	ws.AsyncHandshake(fmt.Sprintf("ws://127.0.0.1:%d", <-srv.portChan), func(err error) {
 		if err != nil {
 			assertState(t, ws, StateTerminated)
 		} else {
@@ -564,7 +564,7 @@ func TestClientSuccessfulHandshakeWithExtraHeaders(t *testing.T) {
 	}
 
 	ws.AsyncHandshake(
-		fmt.Sprintf("ws://localhost:%d", <-srv.portChan),
+		fmt.Sprintf("ws://127.0.0.1:%d", <-srv.portChan),
 		func(err error) {
 			if err != nil {
 				assertState(t, ws, StateTerminated)
@@ -1670,7 +1670,7 @@ func TestClientAbnormalClose(t *testing.T) {
 	ws, err := NewWebsocketStream(ioc, nil, RoleClient)
 	assert.Nil(err)
 
-	err = ws.Handshake(fmt.Sprintf("ws://localhost:%d", <-srv.portChan))
+	err = ws.Handshake(fmt.Sprintf("ws://127.0.0.1:%d", <-srv.portChan))
 	assert.Nil(err)
 	assert.Equal(ws.State(), StateActive) // Verify WebSocket active
 
@@ -1711,7 +1711,7 @@ func TestClientAsyncAbnormalClose(t *testing.T) {
 	assert.Nil(err)
 
 	done := false
-	ws.AsyncHandshake(fmt.Sprintf("ws://localhost:%d", <-srv.portChan), func(err error) {
+	ws.AsyncHandshake(fmt.Sprintf("ws://127.0.0.1:%d", <-srv.portChan), func(err error) {
 		assert.Nil(err)
 		assert.Equal(ws.State(), StateActive) // Verify WebSocket active
 
@@ -1752,7 +1752,7 @@ func TestStreamResolveUrl(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = ws.resolve("ws://localhost:8080")
+	_, err = ws.resolve("ws://127.0.0.1:8080")
 	if err != nil {
 		t.Fatalf("valid url could not be resolved: %v", err)
 	}
@@ -1775,7 +1775,10 @@ func TestMaxMsgSizeBeforeHandshake(t *testing.T) {
 	go func() {
 		defer srv.Close()
 		assert.Nil(srv.Accept(MockServerDynamicAddr))
-		assert.Nil(srv.Write(make([]byte, msgSize+1)))
+		// not asserted: the client tears the connection down on seeing the
+		// oversized header, racing this write, which can then fail with
+		// EPIPE/ECONNRESET after the test has completed
+		_ = srv.Write(make([]byte, msgSize+1))
 	}()
 
 	ioc := sonic.MustIO()
@@ -1794,7 +1797,7 @@ func TestMaxMsgSizeBeforeHandshake(t *testing.T) {
 
 	// we now check if the max message size is enforced
 	done := false
-	ws.AsyncHandshake(fmt.Sprintf("ws://localhost:%d", <-srv.portChan), func(err error) {
+	ws.AsyncHandshake(fmt.Sprintf("ws://127.0.0.1:%d", <-srv.portChan), func(err error) {
 		assert.Nil(err)
 
 		ws.AsyncNextFrame(func(err error, f Frame) {
@@ -1827,7 +1830,7 @@ func TestMaxMsgSizeAfterHandshake(t *testing.T) {
 
 	// we now check if the max message size is enforced
 	done := false
-	ws.AsyncHandshake(fmt.Sprintf("ws://localhost:%d", <-srv.portChan), func(err error) {
+	ws.AsyncHandshake(fmt.Sprintf("ws://127.0.0.1:%d", <-srv.portChan), func(err error) {
 		assert.Nil(err)
 
 		// check that increasing it after the handshake works

--- a/codec/websocket/test_main.go
+++ b/codec/websocket/test_main.go
@@ -14,10 +14,10 @@ import (
 
 // MockServer is a server which can be used to test the WebSocket client.
 type MockServer struct {
-	ln     net.Listener
-	conn   net.Conn
-	closed int32
-	port   int32
+	ln       net.Listener
+	conn     net.Conn
+	closed   int32
+	port     int32
 	portChan chan int
 
 	Upgrade *http.Request
@@ -32,9 +32,13 @@ func NewMockServer() *MockServer {
 // Accept starts the mock server on the specified address.
 // If MockServerDynamicAddr is provided as the address, the server binds to any available port.
 const MockServerDynamicAddr = ""
+
 func (s *MockServer) Accept(addr string) (err error) {
 	if addr == MockServerDynamicAddr {
-		s.ln, err = net.Listen("tcp", "localhost:0")
+		// 127.0.0.1, not "localhost", here and on the dialing side: on a
+		// dual-stack machine "localhost" can resolve to ::1, where the
+		// ephemeral port may be occupied by an unrelated service
+		s.ln, err = net.Listen("tcp", "127.0.0.1:0")
 	} else {
 		s.ln, err = net.Listen("tcp", addr)
 	}


### PR DESCRIPTION
Follow-up promised in #166 — fixes the two sources of test flakiness diagnosed there.

**1. `TestMaxMsgSizeBeforeHandshake` goroutine panic.** The server goroutine asserted on the result of writing an over-max-size frame, but the client is supposed to abort reading that frame, tearing the connection down while the write is still in flight. The write then fails with EPIPE/ECONNRESET after the test has completed and testify panics. The write's error is now ignored; the test's real assertion — the client rejecting the frame — is unchanged.

**2. Dual-stack `localhost` dials.** Tests dialed `ws://localhost:<port>` while `MockServer` listened on a single stack; on a dual-stack machine `localhost` resolves to `::1` first, so an unrelated service on that port gets the handshake. All dials and listens are now pinned to `127.0.0.1`.

Before: 8/10 full-suite runs failed on this machine. After: 0 failures in 25 consecutive runs. Test files only.