### PR TITLE
internal: arm timerfd against CLOCK_MONOTONIC (fixes #63)

### DIFF
--- a/internal/timer_linux.go
+++ b/internal/timer_linux.go
@@ -20,7 +20,7 @@ type Timer struct {
 }
 
 func NewTimer(p Poller) (*Timer, error) {
-	fd, err := unix.TimerfdCreate(unix.CLOCK_REALTIME, unix.TFD_NONBLOCK)
+	fd, err := unix.TimerfdCreate(unix.CLOCK_MONOTONIC, unix.TFD_NONBLOCK)
 	if err != nil {
 		return nil, os.NewSyscallError("timerfd_create", err)
 	}


### PR DESCRIPTION
Fixes #63.

Sonic's timers are all duration-based (`ScheduleOnce`/`ScheduleRepeating` — "fire in `dur` from now") and `Timer.Set` arms the timerfd relatively (`timerfd_settime` flags=0), so the monotonic clock is the right one to measure that. `CLOCK_REALTIME` can jump (NTP steps, manual `settimeofday`); POSIX shields relative timers from jumps, but there's no reason to depend on that shield when `CLOCK_MONOTONIC` states the intent directly.

No call site reads the timer's absolute value and arming stays relative, so nothing observable changes except jump-immunity. The kqueue implementation (`EVFILT_TIMER`) is already interval-based and needs no change.